### PR TITLE
3: Package renamed; Dependencies updated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
-__version="1.0.0"
+__version="1.0.1"
 
 spec = {
-    "name": "oc_connections",
+    "name": "oc-connections",
     "version": __version,
     "license": "Apache License 2.0",
     "description": "Connection Manages",
@@ -11,8 +11,8 @@ spec = {
     "long_description_content_type": "text/plain",
     "packages": ["oc_connections"],
     "install_requires": [
-      'oc_cdtapi', 
-      'oc_pyfs',
+      'oc-cdtapi', 
+      'oc-pyfs',
       'pysmb'
     ],
     "package_data": {},


### PR DESCRIPTION
- Package re-named to *oc_connections* in order to fit Regulations
- Dependencies updated (due to low-level packages were renamed in order to fit Regulations)